### PR TITLE
fix: restore .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+CONTENT_SAFETY_KEY="Your Azure OpenAI API key"
+CONTENT_SAFETY_ENDPOINT="Your Azure OpenAI endpoint"


### PR DESCRIPTION
This pull requests adds the `.env` which `azure-ai-content-safety-module.ipynb` relies on. The `.env` file is also mentioned in the [Moderate Content and Detect Harm with Azure AI Content Safety](https://learn.microsoft.com/en-us/training/modules/moderate-content-detect-harm-azure-ai-content-safety-studio/3-prepare) Microsoft Learn module. Without a template a new user might have trouble knowing where to place the file and how to add the necessary variables.